### PR TITLE
Fix missing hotkey strings

### DIFF
--- a/prototypes/hotkey.lua
+++ b/prototypes/hotkey.lua
@@ -4,11 +4,13 @@ data:extend {
 	{
 		type = "custom-input",
 		name = const.EVENTS.gui_hud_toggle,
+		localised_name = {"controls.chv2_toggle_hud"},
 		key_sequence = "CONTROL + SHIFT + S"
 	},
 	{
 		type = "custom-input",
 		name = const.EVENTS.gui_settings_open,
+		localised_name = {"controls.chv2_open_settings_gui"},
 		key_sequence = "CONTROL + ALT + S"
 	}
 }


### PR DESCRIPTION
Fix Control settings showing as ex. _Unknown key: "controls.chv2\_gui\_settings\_open"_